### PR TITLE
Added ecomode to set_device

### DIFF
--- a/pcomfortcloud/session.py
+++ b/pcomfortcloud/session.py
@@ -272,6 +272,9 @@ class Session(object):
 
                 if key == 'airSwingVertical' and isinstance(value, constants.AirSwingUD):
                     airY = value
+                
+                if key == 'eco' and isinstance(value, constants.EcoMode):
+                    parameters['ecoMode'] = value.value
 
         
         # routine to set the auto mode of fan (either horizontal, vertical, both or disabled)


### PR DESCRIPTION
Setting the ecomode didn't work. This PR implements the Ecomode in the set_device method. 