### PR TITLE
print_result: add support of lists

### DIFF
--- a/pcomfortcloud/__main__.py
+++ b/pcomfortcloud/__main__.py
@@ -13,6 +13,11 @@ def print_result(obj, indent = 0):
             print_result(value, indent + 4)
         elif isinstance(value, Enum):
             print(" "*indent + "{0: <{width}}: {1}".format(key, value.name, width=25-indent))
+        elif isinstance(value, list):
+            print(" "*indent + "{0: <{width}}:".format(key, width=25-indent))
+            for elt in value:
+                print_result(elt, indent + 4)
+                print("")
         else:
             print(" "*indent + "{0: <{width}}: {1}".format(key, value, width=25-indent))
 


### PR DESCRIPTION
It is now possible to print a list with a nice formatting.
Something like:
historyDataList          :
    dataNumber           : 0
    consumption          : 0.6610000000000003
    cost                 : 0.0
    averageSettingTemp   : 28.5
    averageInsideTemp    : 26.52083396911621
    averageOutsideTemp   : 30.18181800842285

    dataNumber           : 1
    consumption          : 0.08200000000000002
    cost                 : 0.0
    averageSettingTemp   : 28.5
    averageInsideTemp    : 26.29166603088379
    averageOutsideTemp   : -255.0

instead of:
historyDataList          : [{'dataNumber': 0, 'consumption': 0.001, 'cost': 0.0, 'averageSettingTemp': 28.5, 'averageInsideTemp': 26.0, 'averageOutsideTemp': -255.0}, {'dataNumber': 1, 'consumption': 0.001, 'cost': 0.0, 'averageSettingTemp': 28.5, 'averageInsideTemp': 26.0, 'averageOutsideTemp': -255.0},...