### PR TITLE
Add missing eco arg for eco mode

### DIFF
--- a/pcomfortcloud/__main__.py
+++ b/pcomfortcloud/__main__.py
@@ -207,6 +207,9 @@ def main():
             if args.mode is not None:
                 kwargs['mode'] = pcomfortcloud.constants.OperationMode[args.mode]
 
+            if args.eco is not None:
+                kwargs['eco'] = pcomfortcloud.constants.EcoMode[args.eco]
+
             if args.airSwingHorizontal is not None:
                 kwargs['airSwingHorizontal'] = pcomfortcloud.constants.AirSwingLR[args.airSwingHorizontal]
 


### PR DESCRIPTION
Further to my comment https://github.com/lostfields/python-panasonic-comfort-cloud/pull/6#issuecomment-520083979 here is a PR to add the missing eco mode arg.