### PR TITLE
Fixed the AirSwingLR enum values

### DIFF
--- a/pcomfortcloud/constants.py
+++ b/pcomfortcloud/constants.py
@@ -21,11 +21,11 @@ class AirSwingUD(Enum):
 
 class AirSwingLR(Enum):
     Auto = -1
-    Left = 0
-    LeftMid = 4
+    Left = 1
+    LeftMid = 5
     Mid = 2
-    RightMid = 3
-    Right = 1
+    RightMid = 4
+    Right = 0
 
 class EcoMode(Enum):
     Auto = 0


### PR DESCRIPTION
The AirSwingLR values were incorrect, if the swing mode was set to LeftMid in the app the parser crashed since it returns value 5