### PR TITLE
update header Accept

### DIFF
--- a/pcomfortcloud/session.py
+++ b/pcomfortcloud/session.py
@@ -111,7 +111,7 @@ class Session(object):
             "X-APP-VERSION": "1.10.0",
             "X-User-Authorization": self._vid,
             "User-Agent": "G-RAC",
-            "Accept": "application/json",
+            "Accept": "application/json; charset=utf-8",
             "Content-Type": "application/json"
         }
 


### PR DESCRIPTION
Got 403 Forbidden with "X-APP-VERSION: 1.10.0" again:
ComfortCloud-App has in the header ("Accept", "application/json; charset=utf-8") -> no token creation was possible.