### PR TITLE
Update python-publish.yml us release/v1 instead of master.

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -56,6 +56,6 @@ jobs:
         retention-days: 7
     
     - name: Publish distribution to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This should fix #90

see: https://github.com/pypa/gh-action-pypi-publish?tab=readme-ov-file#-master-branch-sunset-