### PR TITLE
Use raw string for regex to avoid SyntaxWarning

### DIFF
--- a/pcomfortcloud/urls.py
+++ b/pcomfortcloud/urls.py
@@ -20,13 +20,13 @@ def get_groups():
 def status(guid):
     return '{base_url}/deviceStatus/{guid}'.format(
         base_url=BASE_URL,
-        guid=re.sub('(?i)\%2f', 'f', quote_plus(guid))
+        guid=re.sub(r'(?i)\%2f', 'f', quote_plus(guid))
     )
 
 def statusCache(guid):
     return '{base_url}/deviceStatus/now/{guid}'.format(
         base_url=BASE_URL,
-        guid=re.sub('(?i)\%2f', 'f', quote_plus(guid))
+        guid=re.sub(r'(?i)\%2f', 'f', quote_plus(guid))
     )
 
 def control():


### PR DESCRIPTION
in python 3 strings are considered unicode. the `\%` escape used in the regex is therefore treated as an unicode escape instead of a regex character escape. as this is not a valid unicode escape, python 3.12+ throws an SyntaxWarning.

treating the regex string as a raw string fixes the issue.

fixes https://github.com/sockless-coding/panasonic_cc/issues/206