### PR TITLE
small cleaning

### DIFF
--- a/pcomfortcloud/apiclient.py
+++ b/pcomfortcloud/apiclient.py
@@ -174,7 +174,6 @@ class ApiClient():
                     fan_auto = fan_auto | 2
                 else:
                     fan_auto = fan_auto & ~2
-                    print(air_y.name)
                     parameters['airSwingUD'] = air_y.value
 
             if fan_auto == 3:


### PR DESCRIPTION
it seems that one print() was left in script. When set_device() was called it printed airswing in console but nothing else was printed => silent run